### PR TITLE
fix:サーバーをApacheに変更

### DIFF
--- a/src/Procfile
+++ b/src/Procfile
@@ -1,2 +1,2 @@
 //https://devcenter.heroku.com/articles/custom-php-settings
-web: vendor/bin/heroku-php-nginx public/
+web: vendor/bin/heroku-php-apache2 public/


### PR DESCRIPTION
HerokuのサーバーをNginxに変更しようと考えたが、新たにAWSへのデプロイを行うことにしたため、この変更を取り消した。